### PR TITLE
Update Ingress and HPA deployment manifest

### DIFF
--- a/labs/08-ingress/2048-game.yaml
+++ b/labs/08-ingress/2048-game.yaml
@@ -40,7 +40,7 @@ spec:
   selector:
     app.kubernetes.io/name: app-2048
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: game-2048
@@ -54,6 +54,9 @@ spec:
     - http:
         paths:
           - path: /*
+            pathType: Prefix
             backend:
-              serviceName: service-2048
-              servicePort: 80
+              service:
+                name: service-2048
+                port:
+                  number: 80

--- a/labs/09-hpa/2048-deployment-hpa.yaml
+++ b/labs/09-hpa/2048-deployment-hpa.yaml
@@ -12,7 +12,6 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: app-2048
-        app: "2048"
     spec:
       containers:
       - image: alexwhen/docker-2048


### PR DESCRIPTION
Update 2048 game Ingress manifest

- Use non-deprecated API version

Update HPA deployment manifest

- Removed unnecessary label